### PR TITLE
♻️ refactor: 방명록 중복 API 요청 제거 및 코드 최적화

### DIFF
--- a/src/hooks/useGuestbookQuery.ts
+++ b/src/hooks/useGuestbookQuery.ts
@@ -1,18 +1,6 @@
-import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useInfiniteQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { QUERY_KEYS } from '@/constants/queryKeys.constants';
-import {
-  createGuestbookEntry,
-  fetchGuestbookEntries,
-  fetchGuestbookEntriesPaginated,
-} from '@/services/guestbookService';
-
-// 방명록 목록 조회
-export const useGuestbookEntries = () => {
-  return useQuery({
-    queryKey: QUERY_KEYS.GUESTBOOK.ALL,
-    queryFn: fetchGuestbookEntries,
-  });
-};
+import { createGuestbookEntry, fetchGuestbookEntriesPaginated } from '@/services/guestbookService';
 
 // 방명록 무한 스크롤 조회
 export const useGuestbookInfiniteEntries = (pageSize = 10) => {

--- a/src/pages/GuestbookPage.tsx
+++ b/src/pages/GuestbookPage.tsx
@@ -3,28 +3,22 @@ import { Button } from '@/components/Button';
 import { GuestbookForm, GuestbookList } from '@/components/Guestbook';
 import { NotificationModal } from '@/components/NotificationModal';
 import { useGuestbookForm } from '@/hooks/useGuestbookForm';
-import { useGuestbookEntries, useGuestbookInfiniteEntries } from '@/hooks/useGuestbookQuery';
+import { useGuestbookInfiniteEntries } from '@/hooks/useGuestbookQuery';
 
 export const GuestbookPage = () => {
   const navigate = useNavigate();
-  const { data: entries = [], isLoading, error, refetch } = useGuestbookEntries();
   const infinite = useGuestbookInfiniteEntries(10);
   const { loading, handleSubmit, notification, hideNotification } = useGuestbookForm();
 
   const flatInfiniteItems = infinite.data?.pages.flatMap((p) => p.items) ?? [];
-  const shouldUseInfinite = (entries?.length ?? 0) >= 10;
-  const totalCount = infinite.data?.pages[0]?.totalCount ?? entries.length;
+  const totalCount = infinite.data?.pages[0]?.totalCount ?? 0;
 
   // 에러 메시지 처리
-  const errorMessage = shouldUseInfinite ? infinite.error?.message || null : error?.message || null;
+  const errorMessage = infinite.error?.message || null;
 
   // 재시도 함수
   const handleRetry = () => {
-    if (shouldUseInfinite) {
-      infinite.refetch();
-    } else {
-      refetch();
-    }
+    infinite.refetch();
   };
 
   return (
@@ -53,36 +47,25 @@ export const GuestbookPage = () => {
             <GuestbookForm onSubmit={handleSubmit} loading={loading} />
 
             {/* 방명록 목록 */}
-            {shouldUseInfinite ? (
-              <>
-                <GuestbookList
-                  entries={flatInfiniteItems}
-                  loading={infinite.isLoading}
-                  totalCount={totalCount}
-                  error={errorMessage}
-                  onRetry={handleRetry}
-                />
-                <div className='mt-4 flex justify-center'>
-                  {infinite.hasNextPage && !errorMessage && (
-                    <Button
-                      variant='secondary'
-                      size='sm'
-                      onClick={() => infinite.fetchNextPage()}
-                      disabled={infinite.isFetchingNextPage}
-                    >
-                      {infinite.isFetchingNextPage ? '불러오는 중...' : '더 보기'}
-                    </Button>
-                  )}
-                </div>
-              </>
-            ) : (
-              <GuestbookList
-                entries={entries}
-                loading={isLoading}
-                error={errorMessage}
-                onRetry={handleRetry}
-              />
-            )}
+            <GuestbookList
+              entries={flatInfiniteItems}
+              loading={infinite.isLoading}
+              totalCount={totalCount}
+              error={errorMessage}
+              onRetry={handleRetry}
+            />
+            <div className='mt-4 flex justify-center'>
+              {infinite.hasNextPage && !errorMessage && (
+                <Button
+                  variant='secondary'
+                  size='sm'
+                  onClick={() => infinite.fetchNextPage()}
+                  disabled={infinite.isFetchingNextPage}
+                >
+                  {infinite.isFetchingNextPage ? '불러오는 중...' : '더 보기'}
+                </Button>
+              )}
+            </div>
           </div>
         </div>
       </div>

--- a/src/services/guestbookService.ts
+++ b/src/services/guestbookService.ts
@@ -12,31 +12,6 @@ export class GuestbookServiceError extends Error {
   }
 }
 
-// 방명록 목록 조회 (공개)
-export const fetchGuestbookEntries = async (): Promise<GuestbookEntry[]> => {
-  try {
-    const { data, error } = await supabase
-      .from('guestbook')
-      .select('id, name, message, created_at')
-      .eq('is_visible', true)
-      .order('created_at', { ascending: false });
-
-    if (error) {
-      throw new GuestbookServiceError(`방명록 목록 조회 실패: ${error.message}`, error.code);
-    }
-
-    return data || [];
-  } catch (error) {
-    console.error('방명록 목록 조회 중 오류:', error);
-    if (error instanceof GuestbookServiceError) {
-      throw error;
-    }
-    throw new GuestbookServiceError(
-      error instanceof Error ? error.message : '알 수 없는 오류가 발생했습니다.'
-    );
-  }
-};
-
 // 방명록 페이지네이션 조회 (무한 스크롤)
 export const fetchGuestbookEntriesPaginated = async (
   limit: number,


### PR DESCRIPTION
- 방명록 페이지 중복 API 호출 문제 해결 (2개 → 1개 요청)
- useGuestbookEntries 훅 제거하고 무한스크롤 방식으로 통일
- fetchGuestbookEntries 서비스 함수 제거
- 조건부 렌더링 로직 단순화
- 불필요한 import 정리 (useQuery 제거)